### PR TITLE
fix config.js "isLocal" argument

### DIFF
--- a/locale/config.js
+++ b/locale/config.js
@@ -33,4 +33,4 @@ dayjs.locale({
     y: 'یک سال',
     yy: '%d سال'
   }
-}, null, true);
+}, null, false);


### PR DESCRIPTION
Hello, for the `dayjs.locale` in the `config.js` file, the third argument (isLocal) should be `false` instead of `true`.